### PR TITLE
Fix variable name inconsistency in 013-static-connection-pool.md

### DIFF
--- a/src/013-static-connection-pool.md
+++ b/src/013-static-connection-pool.md
@@ -36,12 +36,12 @@ async fn main() {
 }
 ```
 
-Now any scopes inside of the same module can access the `DB` static variable and use it as a connection to the database without establishing connection everytime. For example
+Now any scopes inside of the same module can access the `DB_CLIENT` static variable and use it as a connection to the database without establishing connection everytime. For example
 
 ```rust, no_run
 fn a_function() -> Result<(), !> {
-    DB.do_something().await?;
+    DB_CLIENT.do_something().await?;
 }
 ```
 
-For `DB` to be visible from other modules, simply add `pub` in front of `static ref DB:...`.
+For `DB_CLIENT` to be visible from other modules, simply add `pub` in front of `static DB_CLIENT:...`.


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

## New Features

## Bug Fixes

- [ ] The last part of 013-static-connection-pool.md uses an old variable name `DB` that existed before [a34e6e5](https://github.com/SeaQL/sea-orm-cookbook/commit/a34e6e587b3b58bb33d32e502f2a72c0ddc3cc3a)
 
## Changes

- [ ] `DB` -> `DB_CLIENT`
